### PR TITLE
add `--network host` for docker to be able to make SSL requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ docker run \
     -v /home/ubuntu/codabench:/codabench \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -d \
+    --network host \
     --env-file .env \
     --restart unless-stopped \
     --log-opt max-size=50m \


### PR DESCRIPTION
Strangely enough, I noticed on the worker outside of the docker container requests worked:

```bash
$ curl https://www.codabench.org
<html>....
```

but inside the container they did not:

```bash
$ docker run -it codalab/competitions-v2-compute-worker bash
root@cce68cb6e46b:/# curl https://www.codabench.org

# .. hangs here
```

then with `--network host` it **works!**
```bash
$ docker run -it --network host codalab/competitions-v2-compute-worker bash
root@worker-networked-storage:/# curl https://www.codabench.org
<html>...
```

This setting makes the docker container appear more closely like the host. I am not sure of security concerns, but the underlying docker container that is actually doing the computation will not have this setting -- so no clinician code will appear as the host .. this may be necessary though for some competitions/benchmarks?